### PR TITLE
Update deps and add ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/test2/index.js
+++ b/test2/index.js
@@ -12,4 +12,6 @@ config.views.system.packages.push({
   manifest: path.join(rootPath, 'package.json')
 });
 
+config.views.system.importAllIgnore.push('bootstrap');
+
 bedrock.start();

--- a/test2/package.json
+++ b/test2/package.json
@@ -10,7 +10,7 @@
     "bedrock": "^1.4.1",
     "bedrock-angular": "^3.0.0",
     "bedrock-angular-alert": "^3.0.2",
-    "bedrock-angular-modal": "^5.0.2",
+    "bedrock-angular-modal": "digitalbazaar/bedrock-angular-modal#bootstrap",
     "bedrock-angular-model": "^3.0.2",
     "bedrock-angular-navbar": "^4.0.6",
     "bedrock-express": "^2.0.6",


### PR DESCRIPTION
These are the changes required to get this example working.

This is a temporary workaround while we figure out how we're dealing with the bootstrap javascript that we  do not want to load.

Ultimately, the `importAllIIgnore` added here will not be necessary.